### PR TITLE
A couple of fixes

### DIFF
--- a/src/vmq_diversity_cli.erl
+++ b/src/vmq_diversity_cli.erl
@@ -131,7 +131,7 @@ path_keyspec() ->
                                case filelib:is_file(Path) of
                                    true -> Path;
                                    false ->
-                                       {error, {invalid_key_value, 'path'}}
+                                       {error, {invalid_value, Path}}
                                end
                        end}]}.
 

--- a/src/vmq_diversity_plugin.erl
+++ b/src/vmq_diversity_plugin.erl
@@ -321,6 +321,8 @@ all_till_ok([Pid|Rest], HookName, Args) ->
                 ValidatedModifiers ->
                     {ok, ValidatedModifiers}
             end;
+        false ->
+            error;
         error ->
             error;
         _ ->

--- a/test/vmq_diversity_plugin_SUITE.erl
+++ b/test/vmq_diversity_plugin_SUITE.erl
@@ -66,7 +66,7 @@ all() ->
 auth_on_register_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), allowed_subscriber_id(), username(), password(), true]),
-    {error, [next]} = vmq_plugin:all_till_ok(auth_on_register,
+    {error, [error]} = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), not_allowed_subscriber_id(), username(), password(), true]),
     {error, [next]} = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), ignored_subscriber_id(), username(), password(), true]),
@@ -76,7 +76,7 @@ auth_on_register_test(_) ->
 auth_on_publish_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), allowed_subscriber_id(), 1, topic(), payload(), false]),
-    {error, [next]} = vmq_plugin:all_till_ok(auth_on_publish,
+    {error, [error]} = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), not_allowed_subscriber_id(), 1, topic(), payload(), false]),
     {error, [next]} = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), ignored_subscriber_id(), 1, topic(), payload(), false]),
@@ -85,7 +85,7 @@ auth_on_publish_test(_) ->
 auth_on_subscribe_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), allowed_subscriber_id(), [{topic(), 1}]]),
-    {error, [next]} = vmq_plugin:all_till_ok(auth_on_subscribe,
+    {error, [error]} = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), not_allowed_subscriber_id(), [{topic(), 1}]]),
     {error, [next]} = vmq_plugin:all_till_ok(auth_on_subscribe,
                       [username(), ignored_subscriber_id(), [{topic(), 1}]]),


### PR DESCRIPTION
- a small clique error
- make lua scripts returning `false` be handled as `error` instead of falling into the `next` case.
