### PR TITLE
Don't disable module hooks explicitly

### DIFF
--- a/src/vmq_diversity_plugin.erl
+++ b/src/vmq_diversity_plugin.erl
@@ -170,9 +170,6 @@ handle_info({'DOWN', _, process, Pid, _}, State) ->
 %% @end
 %%--------------------------------------------------------------------
 terminate(_Reason, _State) ->
-    ets:foldl(fun({HookName, _}, _) ->
-                      disable_hook(HookName)
-              end, ok, ?TBL),
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This is now handled by vmq_plugin.

Just tested this against the new vmq_plugin using vernemq master and it looks good: when the diversity plugin is stopped all the diversity module plugins are removed.

/cc @dergraf 
