### PR TITLE
Handle undefined credentials

### DIFF
--- a/src/vmq_diversity_plugin.erl
+++ b/src/vmq_diversity_plugin.erl
@@ -194,13 +194,13 @@ auth_on_register(Peer, SubscriberId, UserName, Password, CleanSession) ->
                                    {port, Port},
                                    {mountpoint, MP},
                                    {client_id, ClientId},
-                                   {username, UserName},
-                                   {password, Password},
+                                   {username, nilify(UserName)},
+                                   {password, nilify(Password)},
                                    {clean_session, CleanSession}]).
 
 auth_on_publish(UserName, SubscriberId, QoS, Topic, Payload, IsRetain) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
-    all_till_ok(auth_on_publish, [{username, UserName},
+    all_till_ok(auth_on_publish, [{username, nilify(UserName)},
                                   {mountpoint, MP},
                                   {client_id, ClientId},
                                   {qos, QoS},
@@ -210,7 +210,7 @@ auth_on_publish(UserName, SubscriberId, QoS, Topic, Payload, IsRetain) ->
 
 auth_on_subscribe(UserName, SubscriberId, Topics) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
-    all_till_ok(auth_on_subscribe, [{username, UserName},
+    all_till_ok(auth_on_subscribe, [{username, nilify(UserName)},
                                     {mountpoint, MP},
                                     {client_id, ClientId},
                                     {topics, [[unword(T), QoS]
@@ -223,11 +223,11 @@ on_register(Peer, SubscriberId, UserName) ->
                            {port, Port},
                            {mountpoint, MP},
                            {client_id, ClientId},
-                           {username, UserName}]).
+                           {username, nilify(UserName)}]).
 
 on_publish(UserName, SubscriberId, QoS, Topic, Payload, IsRetain) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
-    all(on_publish, [{username, UserName},
+    all(on_publish, [{username, nilify(UserName)},
                      {mountpoint, MP},
                      {client_id, ClientId},
                      {qos, QoS},
@@ -237,7 +237,7 @@ on_publish(UserName, SubscriberId, QoS, Topic, Payload, IsRetain) ->
 
 on_subscribe(UserName, SubscriberId, Topics) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
-    all(on_subscribe, [{username, UserName},
+    all(on_subscribe, [{username, nilify(UserName)},
                        {mountpoint, MP},
                        {client_id, ClientId},
                        {topics, [[unword(T), QoS]
@@ -245,7 +245,7 @@ on_subscribe(UserName, SubscriberId, Topics) ->
 
 on_unsubscribe(UserName, SubscriberId, Topics) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
-    all_till_ok(on_unsubscribe, [{username, UserName},
+    all_till_ok(on_unsubscribe, [{username, nilify(UserName)},
                                  {mountpoint, MP},
                                  {client_id, ClientId},
                                  {topics, [unword(T)
@@ -253,7 +253,7 @@ on_unsubscribe(UserName, SubscriberId, Topics) ->
 
 on_deliver(UserName, SubscriberId, Topic, Payload) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
-    all_till_ok(on_deliver, [{username, UserName},
+    all_till_ok(on_deliver, [{username, nilify(UserName)},
                              {mountpoint, MP},
                              {client_id, ClientId},
                              {topic, unword(Topic)},
@@ -402,3 +402,9 @@ peer({Peer, Port}) when is_tuple(Peer) and is_integer(Port) ->
 
 subscriber_id({"", ClientId}) -> {<<>>, ClientId};
 subscriber_id({MP, ClientId}) -> {list_to_binary(MP), ClientId}.
+
+nilify(undefined) ->
+    nil;
+nilify(Val) ->
+    Val.
+

--- a/test/plugin_test.lua
+++ b/test/plugin_test.lua
@@ -12,6 +12,11 @@ function auth_on_register(reg)
     assert(reg.addr == "192.168.123.123")
     assert(reg.port == 12345)
     assert(reg.mountpoint == "")
+    if reg.client_id == "undefined_creds" then
+       assert(reg.username == nil)
+       assert(reg.password == nil)
+       return true
+    end
     assert(reg.username == "test-user")
     assert(reg.password == "test-password")
     assert(reg.clean_session == true)

--- a/test/vmq_diversity_plugin_SUITE.erl
+++ b/test/vmq_diversity_plugin_SUITE.erl
@@ -19,7 +19,8 @@
          on_offline_message_test/1,
          on_client_wakeup_test/1,
          on_client_offline_test/1,
-         on_client_gone_test/1
+         on_client_gone_test/1,
+         auth_on_register_undefined_creds_test/1
         ]).
 
 %% ===================================================================
@@ -57,7 +58,8 @@ all() ->
      on_offline_message_test,
      on_client_wakeup_test,
      on_client_offline_test,
-     on_client_gone_test
+     on_client_gone_test,
+     auth_on_register_undefined_creds_test
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -121,6 +123,11 @@ on_client_offline_test(_) ->
 on_client_gone_test(_) ->
     [next] = vmq_plugin:all(on_client_gone, [allowed_subscriber_id()]).
 
+auth_on_register_undefined_creds_test(_) ->
+    Username = undefined,
+    Password = undefined,
+    ok = vmq_plugin:all_till_ok(auth_on_register,
+                      [peer(), {"", <<"undefined_creds">>}, Username, Password, true]).
 
 peer() -> {{192, 168, 123, 123}, 12345}.
 


### PR DESCRIPTION
Before undefined credentials would be passed as the string `undefined`
to lua. This makes sure to convert the undefined credentials to the
`nil` value in lua so they can be distinguised and handled properly.

fixes #5 

@dergraf please review.